### PR TITLE
Revive the TilesetBuilder

### DIFF
--- a/FormBuilder.cs
+++ b/FormBuilder.cs
@@ -82,7 +82,7 @@ namespace OpenRA.TilesetBuilder
 
 			var size = int.Parse(tsize);
 
-			var yaml = MiniYaml.DictFromFile("OpenRA.TilesetBuilder/defaults.yaml");
+			var yaml = MiniYaml.DictFromFile("defaults.yaml");
 			terrainDefinition = yaml["Terrain"].ToDictionary().Values.Select(y => new TerrainTypeInfo(y)).ToDictionary(t => t.Type);
 			var i = 0;
 			surface1.Icon = new Bitmap[terrainDefinition.Keys.Count];

--- a/OpenRA.TilesetBuilder.csproj
+++ b/OpenRA.TilesetBuilder.csproj
@@ -35,7 +35,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <OutputPath>..\</OutputPath>
+    <OutputPath>.\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <PlatformTarget>x86</PlatformTarget>
@@ -44,6 +44,10 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="OpenRA.Game">
+      <HintPath>..\OpenRA.Game.exe</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
@@ -105,13 +109,6 @@
     <Compile Include="FormNew.Designer.cs">
       <DependentUpon>FormNew.cs</DependentUpon>
     </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">
-      <Project>{0DFB103F-2962-400F-8C6D-E2C28CCBA633}</Project>
-      <Name>OpenRA.Game</Name>
-      <Private>False</Private>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="tilesetbuilder_icon copy.ico" />

--- a/OpenRA.TilesetBuilder.sln
+++ b/OpenRA.TilesetBuilder.sln
@@ -1,0 +1,17 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRA.TilesetBuilder", "OpenRA.TilesetBuilder.csproj", "{1A8E50CC-EE32-4E57-8842-0C39C8EA7541}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1A8E50CC-EE32-4E57-8842-0C39C8EA7541}.Debug|x86.ActiveCfg = Debug|x86
+		{1A8E50CC-EE32-4E57-8842-0C39C8EA7541}.Debug|x86.Build.0 = Debug|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Open indexed PNG files and export them into Westwood 2D terrain tile files.
 ![Screenshot](https://camo.githubusercontent.com/0194457c97c9cd10be75cb7be8f62135f4238a55/687474703a2f2f692e696d6775722e636f6d2f33437538392e706e67)
 
 More info on this wiki page: https://github.com/OpenRA/TilesetBuilder/wiki
+
+Build instructions:
+
+Copy the entire TilesetBuilder directory inside OpenRA's root directory. Build OpenRA if you haven't. Open the TilesetBuilder directory and run make.cmd by double-clicking.

--- a/make.cmd
+++ b/make.cmd
@@ -1,0 +1,1 @@
+@powershell -NoProfile -ExecutionPolicy Unrestricted -File make.ps1 %*

--- a/make.ps1
+++ b/make.ps1
@@ -1,0 +1,38 @@
+function FindMSBuild
+{
+	$msBuildVersions = @("4.0")
+	foreach ($msBuildVersion in $msBuildVersions)
+	{
+		$key = "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\{0}" -f $msBuildVersion
+		$property = Get-ItemProperty $key -ErrorAction SilentlyContinue
+		if ($property -eq $null -or $property.MSBuildToolsPath -eq $null)
+		{
+			continue
+		}
+		$path = Join-Path $property.MSBuildToolsPath -ChildPath "MSBuild.exe"
+		if (Test-Path $path)
+		{
+			return $path
+		}
+	}
+	return $null
+}
+
+$msBuild = FindMSBuild
+$msBuildArguments = "/t:Rebuild /nr:false"
+if ($msBuild -eq $null)
+{
+	echo "Unable to locate an appropriate version of MSBuild."
+}
+else
+{
+	$proc = Start-Process $msBuild $msBuildArguments -NoNewWindow -PassThru -Wait
+	if ($proc.ExitCode -ne 0)
+	{
+		echo "Build failed."
+	}
+	else
+	{
+		echo "Build succeeded."
+	}
+}


### PR DESCRIPTION
This fixes a couple of issues caused by separating it from the main repository, adds a `.sln` to enable MSBUILD to build it directly and adds a build script. Also updates the README with build instructions.

Also closes #2 btw.
